### PR TITLE
 Add missing constructor.

### DIFF
--- a/Sqlite.alusus
+++ b/Sqlite.alusus
@@ -71,6 +71,9 @@ type SQLite3 {
     use Srl;
     def _db: ptr[SQLite3];
 
+    handler this~init() {
+    }
+
     handler this~init(filename: ptr[array[Char]]) {
         _open(filename, this._db~ptr);
     }


### PR DESCRIPTION
 Latest changes in Alusus require an empty constructor be defined for
cases where we instantiate SQLite3 without any parameters.